### PR TITLE
Support the aarch64-linux-android target

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,7 @@ jobs:
           - i586-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
           - armv7-unknown-linux-gnueabihf
+          - aarch64-linux-android
     steps:
     - uses: actions/checkout@v1
     - name: Install toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["linux", "futex"]
 categories = ["concurrency", "os::unix-apis"]
 
 [dependencies]
-libc = "0.2.132"
+libc = "0.2.155"

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -74,7 +74,11 @@ impl FutexCall {
 			self.val3,
 		) as i32;
 		if result == -1 {
-			Err(Error(*libc::__errno_location()))
+			#[cfg(target_os = "linux")]
+			let errno = *libc::__errno_location();
+			#[cfg(target_os = "android")]
+			let errno = *libc::__errno();
+			Err(Error(errno))
 		} else {
 			Ok(result)
 		}


### PR DESCRIPTION
Tested primarily through a modified build of https://github.com/rtzoeller/rust-priority-inheriting-lock, both on real hardware (but without root/the ability to verify priority inheritance) and in an Android virtual device verifying priority inheritance works as expected.