### PR TITLE
Use os::linux-apis category instead of os::unix-apis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "BSD-2-Clause"
 repository = "https://github.com/m-ou-se/linux-futex"
 readme = "README.md"
 keywords = ["linux", "futex"]
-categories = ["concurrency", "os::unix-apis"]
+categories = ["concurrency", "os::linux-apis"]
 
 [dependencies]
 libc = "0.2.132"


### PR DESCRIPTION
As futexes are Linux-specific, it feels appropriate to put this under the `os::linux-apis` category rather than `os::unix-apis`.

Full list of categories [here](https://crates.io/category_slugs).